### PR TITLE
Bump dependency for nowadays cabal environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake;

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ cabal-dev
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.config
+
+dist-newstyle
+.direnv

--- a/Control/Arrow/Needle/Internal/UnevenGrid.hs
+++ b/Control/Arrow/Needle/Internal/UnevenGrid.hs
@@ -8,7 +8,7 @@ Maintainer  : jjvk2@cam.ac.uk
 Implements a 'Grid' data structure which can be examined and moved around with a monad 'GridExamine', used in needle parsing.
 -}
 
-{-# LANGUAGE DeriveFunctor, OverloadedLists, GeneralizedNewtypeDeriving, TupleSections#-}
+{-# LANGUAGE DeriveFunctor, GeneralizedNewtypeDeriving, TupleSections #-}
 
 module Control.Arrow.Needle.Internal.UnevenGrid (
     -- * Grids
@@ -43,8 +43,8 @@ import Prelude as Pre
 import Data.Foldable as F
 
 import Data.Vector as V
-import Data.Maybe 
-import Data.List 
+import Data.Maybe
+import Data.List
 import Data.Sequence as S
 
 import Control.Applicative
@@ -68,7 +68,7 @@ import Control.Arrow
 newtype Grid e = Grid { rows :: Vector (GridRow e) }
     deriving (Eq, Functor, Show)
 
-newtype GridRow e = GridRow { elements :: Vector (GridElem e) } 
+newtype GridRow e = GridRow { elements :: Vector (GridElem e) }
     deriving (Eq, Functor, Show)
 
 fromLeft :: GridRow e -> Int -> Maybe Int
@@ -113,8 +113,8 @@ height = V.length . rows
 
 (!!?) :: Grid e -> GridPosition -> Maybe e
 (!!?) grid (rowPos, elemPos) = do
-    row <- rows grid !? rowPos
-    element <- elements row !? elemPos
+    row <- rows grid V.!? rowPos
+    element <- elements row V.!? elemPos
     return $ unwrap element
 
 -- | Return a list of positions satisfying a predicate in a grid, in reading order.
@@ -160,8 +160,8 @@ here = do
     grid <- getGrid
     (rowPos, elemPos) <- getPosition
     return $ do
-        row <- rows grid !? rowPos
-        element <- elements row !? elemPos
+        row <- rows grid V.!? rowPos
+        element <- elements row V.!? elemPos
         return element
 
 -- | Get the element at the current position.
@@ -177,7 +177,7 @@ hereGet = do
 leftGet :: GridExamine e (Maybe e)
 leftGet = do
     (rowPos, elemPos) <- getPosition
-    if elemPos > 0 
+    if elemPos > 0
         then putPosition (rowPos, elemPos - 1) >> (hereGet)
         else return Nothing
 
@@ -189,8 +189,8 @@ rightGet = do
     grid <- getGrid
     (rowPos, elemPos) <- getPosition
     fromMaybe (return Nothing) $ do
-        row <- rows grid !? elemPos 
-        element <- elements row !? (elemPos + 1)
+        row <- rows grid V.!? elemPos
+        element <- elements row V.!? (elemPos + 1)
         return $ putPosition (rowPos, elemPos + 1) >> return (Just $ unwrap element)
 
 -- | Move to and return the grid element above the column a certain distance 
@@ -204,7 +204,7 @@ rUpGet n = do
     (rowPos, _) <- getPosition
     fromMaybe (return Nothing) $ do
         currentElement <- mCurrentElement
-        newRow <- rows grid !? (rowPos - 1)
+        newRow <- rows grid V.!? (rowPos - 1)
         i <- fromLeft newRow (end currentElement - 1 - n)
         return $ putPosition (rowPos - 1, i) >> hereGet
 
@@ -219,7 +219,7 @@ rDownGet n = do
     (rowPos, _) <- getPosition
     fromMaybe (return Nothing) $ do
         currentElement <- mCurrentElement
-        newRow <- rows grid !? (rowPos + 1)
+        newRow <- rows grid V.!? (rowPos + 1)
         i <- fromLeft newRow (end currentElement - 1 - n)
         return $ putPosition (rowPos + 1, i) >> hereGet
 
@@ -232,9 +232,9 @@ lUpGet n = do
     grid <- getGrid
     (rowPos, elemPos) <- getPosition
     fromMaybe (return Nothing) $ do
-        row <- rows grid !? rowPos
-        let start = fromMaybe 0 $ end <$> (elements row !? (elemPos - 1))
-        newRow <- rows grid !? (rowPos - 1)
+        row <- rows grid V.!? rowPos
+        let start = fromMaybe 0 $ end <$> (elements row V.!? (elemPos - 1))
+        newRow <- rows grid V.!? (rowPos - 1)
         i <- fromLeft newRow (start + n)
         return $ putPosition (rowPos - 1, i) >> hereGet
 
@@ -247,9 +247,9 @@ lDownGet n = do
     grid <- getGrid
     (rowPos, elemPos) <- getPosition
     fromMaybe (return Nothing) $ do
-        row <- rows grid !? rowPos
-        let start = fromMaybe 0 $ end <$> (elements row !? (elemPos - 1))
-        newRow <- rows grid !? (rowPos + 1)
+        row <- rows grid V.!? rowPos
+        let start = fromMaybe 0 $ end <$> (elements row V.!? (elemPos - 1))
+        newRow <- rows grid V.!? (rowPos + 1)
         i <- fromLeft newRow (start + n)
         return $ putPosition (rowPos + 1, i) >> hereGet
 
@@ -271,6 +271,6 @@ width = do
     mh <- here
     return $ do
         h <- mh
-        row <- rows grid !? rowPos
-        let start = fromMaybe 0 $ end <$> (elements row !? (elemPos - 1))
+        row <- rows grid V.!? rowPos
+        let start = fromMaybe 0 $ end <$> (elements row V.!? (elemPos - 1))
         return (end h - start)

--- a/Control/Arrow/Needle/Parse.hs
+++ b/Control/Arrow/Needle/Parse.hs
@@ -8,6 +8,8 @@ Maintainer  : jjvk2@cam.ac.uk
 This module's main export is 'parseNeedle', which parses a needle diagram into a `NeedleArrow`.
 -}
 
+{-# LANGUAGE FlexibleContexts #-}
+
 module Control.Arrow.Needle.Parse (
   -- * Parsing needles
     NeedleArrow (..)
@@ -25,7 +27,6 @@ import Data.Either
 import Data.Monoid
 
 import Text.Parsec as P
-import Text.Parsec.Extra (natural)
 import Data.Char
 
 import Control.Monad

--- a/Control/Arrow/Needle/TH.hs
+++ b/Control/Arrow/Needle/TH.hs
@@ -105,7 +105,7 @@ arrowQ arrow = do
 
             return $ InfixE (Just b) (VarE $ mkName ">>>") $ Just
                 $ AppE (VarE $ mkName "arr") 
-                $ LamE [tupleNames aNames] (TupE $ Pre.map VarE aNames)
+                $ LamE [tupleNames aNames] (TupE $ Pre.map (Just .VarE) aNames)
 
     f arrow
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "haskell-flake": {
+      "locked": {
+        "lastModified": 1711149116,
+        "narHash": "sha256-tccTtjRvxrhSJkCnmNwaPrq0DDM3UsM0uiDyW4uJXXc=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "6ae8a85071adfe08d70d9963c526947403c6c070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711106783,
+        "narHash": "sha256-PDwAcHahc6hEimyrgGmFdft75gmLrJOZ0txX7lFqq+I=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a3ed7406349a9335cb4c2a71369b697cecd9d351",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "haskell-flake": "haskell-flake",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    haskell-flake.url = "github:srid/haskell-flake";
+  };
+  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = nixpkgs.lib.systems.flakeExposed;
+      imports = [ inputs.haskell-flake.flakeModule ];
+
+      perSystem = { self', pkgs, ... }: {
+
+        # Typically, you just want a single project named "default". But
+        # multiple projects are also possible, each using different GHC version.
+        haskellProjects.default = {
+          # The base package set representing a specific GHC version.
+          # By default, this is pkgs.haskellPackages.
+          # You may also create your own. See https://zero-to-flakes.com/haskell-flake/package-set
+          # basePackages = pkgs.haskellPackages;
+
+          # Extra package information. See https://zero-to-flakes.com/haskell-flake/dependency
+          #
+          # Note that local packages are automatically included in `packages`
+          # (defined by `defaults.packages` option).
+          #
+          # packages = {
+          #   aeson.source = "1.5.0.0"; # Hackage version override
+          #   shower.source = inputs.shower;
+          # };
+          # settings = {
+          #   aeson = {
+          #     check = false;
+          #   };
+          #   relude = {
+          #     haddock = false;
+          #     broken = false;
+          #   };
+          # };
+
+          # devShell = {
+          #  # Enabled by default
+          #  enable = true;
+          
+          #  # Programs you want to make available in the shell.
+          #  # Default programs can be disabled by setting to 'null'
+          #  tools = hp: { fourmolu = hp.fourmolu; ghcid = null; };
+          
+          #  hlsCheck.enable = true;
+          # };
+        };
+
+        # haskell-flake doesn't set the default package, but you can do it here.
+        packages.default = self'.packages.needle;
+      };
+    };
+}

--- a/needle.cabal
+++ b/needle.cabal
@@ -19,15 +19,14 @@ library
                        Control.Arrow.Needle.Parse
                        Control.Arrow.Needle.TH
   other-modules:       Control.Arrow.Needle.Internal.UnevenGrid
-  build-depends:       base >=4.7 && <4.8
-                     , text >=1.2 && <1.3
+  build-depends:       base >=4.7 && <5
+                     , text >=1.2 && <3
                      , parsec >= 3.1 && <3.2
-                     , parsec-extra >=0.1 && <0.2
-                     , containers >=0.5 && <0.6
-                     , mtl >=2.2 && <2.3
+                     , containers >=0.6 && <0.7
+                     , mtl >=2.2 && <3
                      , template-haskell
-                     , haskell-src-meta >=0.6 && <0.7
-                     , vector >= 0.10 && <0.11
+                     , haskell-src-meta >=0.8 && <0.9
+                     , vector >= 0.10 && <0.14
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
There are 2 mainly changes:

* bump dependencies
  * disable unused `OverloadedLists` extension
  * use `V.!?` instead of `.!?` cause now `Data.Sequence` also has `(.!?)`
  * use `Just .VarE` instead of `VarE` for `ExpQ` constructing cause now `TupE :: [Maybe Exp] %1 -> Exp` ( so sadly old `template-haskell` is not support now )
 * add nix flake & `.direnv` for declaring developing environment, will also be useful for future bumping

There also be some lint I can do, but I'm not sure how this repo formatted, so I can only keep it as it is.

Sorry for bothering.

Resolves #7